### PR TITLE
Updated header path for semver.hpp (neargye-semver).

### DIFF
--- a/include/Defs.h
+++ b/include/Defs.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <neargye/semver.hpp>
+#include <semver.hpp>
 
 const char* GetAddonName();
 const wchar_t* GetAddonNameW();

--- a/src/UpdateCheck.cpp
+++ b/src/UpdateCheck.cpp
@@ -3,7 +3,7 @@
 #include <sstream>
 
 #include <WinInet.h>
-#include <neargye/semver.hpp>
+#include <semver.hpp>
 
 #include "Utility.h"
 


### PR DESCRIPTION
I think this will address the build issue for https://github.com/Friendly0Fire/GW2Clarity/pull/53

It looks as if vcpkg now downloads `semver.hpp` straight to an include directory, rather than `neargye/semver.hpp`